### PR TITLE
Replace $TEST_RUN indirection with build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ services:
 notifications:
   email: false
 
-env:
-  - TEST_RUN="tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)"
-  - TEST_RUN="tox -e lint"
-
 before_install:
   - psql -c 'create user cheeseshop;' -U postgres
   - psql -c 'ALTER USER cheeseshop CREATEDB;' -U postgres
@@ -23,4 +19,9 @@ install:
   - pip install -r test-requirements.txt
   - pip install .
 
-script: "$TEST_RUN"
+jobs:
+  include:
+    - stage: lint
+      script: tox -e lint
+
+script: tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)


### PR DESCRIPTION
The test run is now separated into two stages: test and lint. Test runs
the py35 and py36 tox jobs normally, while the tox lint job is now
separated off into its own build stage so it only runs once [1].

The reason the `test` stage is not included in the build stages section
is that `script` must be defined for python-based Travis-CI jobs outside
of the `jobs` section [2]. This way, the `test` stage is implicitly
defined by the global `script` definition (`test` is the default name
for this).

Footnotes:
    [1]: https://docs.travis-ci.com/user/build-stages/define-steps/
    [2]: https://github.com/travis-ci/travis-ci/issues/2870

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>